### PR TITLE
Update \RestfulEntityBase::checkEntityAccess() comment.

### DIFF
--- a/plugins/restful/RestfulEntityBase.php
+++ b/plugins/restful/RestfulEntityBase.php
@@ -1180,7 +1180,8 @@ abstract class RestfulEntityBase extends \RestfulDataProviderEFQ implements \Res
    * Check access to CRUD an entity.
    *
    * @param $op
-   *   The operation. Allowed values are "create", "update" and "delete".
+   *   The operation. Allowed values are "view", "create", "update" and
+   *   "delete".
    * @param $entity_type
    *   The entity type.
    * @param $entity


### PR DESCRIPTION
Just override this method and noticed the comment was incorrect and missed out on the 'view' operation in the comment.
